### PR TITLE
Use terminfo database for color support

### DIFF
--- a/install-hammer.sh
+++ b/install-hammer.sh
@@ -17,7 +17,7 @@ FORCE=0
 GUI=1
 SHORTCUT=1
 
-function is-smart-term {
+function supports-256-colors {
 	(( $(tput colors) >= 256 ))
 }
 
@@ -35,7 +35,7 @@ function show-help {
 }
 
 function warn { 
-	if is-smart-term; then
+	if supports-256-colors; then
 		printf '\e[93m'
 	fi
 	echo -e $@
@@ -43,7 +43,7 @@ function warn {
 }
 
 function error { 
-	if is-smart-term; then
+	if supports-256-colors; then
 		printf '\e[91m'
 	fi
 	echo -e "$@"
@@ -54,7 +54,7 @@ function error {
 }
 
 function success { 
-	if is-smart-term; then
+	if supports-256-colors; then
 		printf '\e[92m'
 	fi
 	echo -e "$@"

--- a/install-hammer.sh
+++ b/install-hammer.sh
@@ -18,10 +18,7 @@ GUI=1
 SHORTCUT=1
 
 function is-smart-term {
-	if [ "$TERM" == "xterm-256color" ] || [ "$COLORTERM" == "truecolor" ]; then
-		return 0
-	fi
-	return 1
+	(( $(tput colors) >= 256 ))
 }
 
 function show-help {


### PR DESCRIPTION
From the `terminfo(5)` manual page: Terminfo describes terminals by giving a set of capabilities which they have, by specifying how to perform screen operations, and by specifying padding requirements and initialization sequences. This MR makes use of the `tput(1)` command to query the 'colors' capability, that the `terminfo(5)` manual page describes as the 'maximum number of colors on the screen'.
Along with that, this MR renames the `is-smart-term` function to `supports-256-colors`, as the name better reflects what it now checks for.
    
Before, this was done by checking the `$TERM` and `$COLORTERM` environment variables, which is not very reliable as terminal emulators may choose to use non-standard values.