### PR TITLE
Better dependency checks

### DIFF
--- a/install-hammer.sh
+++ b/install-hammer.sh
@@ -250,6 +250,9 @@ if [ $SHORTCUT -ne 0 ]; then
 	echo "Path=$(realpath "$PWD"/../../)" >> "$P"
 fi
 
+echo "Install Finished"
+echo "Installation complete!"
+echo "You may now launch hammer in WINE"
 [ $GUI -ne 0 ] && zenity --info --title="Install Finished" \
                       --text="Installation complete!\nYou may now launch hammer in WINE" \
                       --width=250

--- a/install-hammer.sh
+++ b/install-hammer.sh
@@ -64,7 +64,7 @@ function success {
 	printf '\e[0m'
 }
 
-function check-program {
+function require-program {
 	if ! which $1 &> /dev/null; then
 		if [ $# -gt 1 ]; then
 			error $2
@@ -117,8 +117,8 @@ for a in $@; do
 done
 
 # Check for required software 
-check-program "wget"
-[ $GUI -ne 0 ] && check-program "zenity"
+require-program "wget"
+[ $GUI -ne 0 ] && require-program "zenity"
 
 # Before we do anything else, show the configuration dialog to the user, if GUI is enabled
 if [ $GUI -ne 0 ]; then
@@ -159,7 +159,7 @@ if [ $GUI -ne 0 ]; then
 fi
 
 # Check WINE in case specified in the GUI
-check-program "$WINE"
+require-program "$WINE"
 
 # Check that the WINE version is new enough...
 VERSION="$("$WINE" --version | grep -Eo "^(wine-)[0-9]")"

--- a/install-hammer.sh
+++ b/install-hammer.sh
@@ -117,7 +117,7 @@ done
 
 # Check for required software 
 check-program "wget"
-check-program "zenity"
+[ $GUI -ne 0 ] && check-program "zenity"
 
 # Before we do anything else, show the configuration dialog to the user, if GUI is enabled
 if [ $GUI -ne 0 ]; then
@@ -249,4 +249,6 @@ if [ $SHORTCUT -ne 0 ]; then
 	echo "Path=$(realpath "$PWD"/../../)" >> "$P"
 fi
 
-zenity --width=250 --info --title="Install Finished" --text="Installation complete!\nYou may now launch hammer in WINE"
+[ $GUI -ne 0 ] && zenity --info --title="Install Finished" \
+                      --text="Installation complete!\nYou may now launch hammer in WINE" \
+                      --width=250

--- a/install-hammer.sh
+++ b/install-hammer.sh
@@ -71,6 +71,7 @@ function check-program {
 		else
 			error "Could not find $1\nPlease install the corresponding package."
 		fi
+		exit 127
 	fi
 }
 


### PR DESCRIPTION
This MR fixes some problems with how dependencies are handled in the `install-hammer.sh` script:
- the program now safely exits with status code 127 when missing a dependency
- `check-program` is renamed to `require-program` to better describe the new behavior
- zenity is now only used when the `--no-gui` flag isn't set, this allows running the script without zenity by setting the `--no-gui` flag
- the program now prints an 'Install Finished' message to `stdout` as zenity no longer relays that information in all scenarios