### PR TITLE
Unscrew BIK-to-WebM conversion

### DIFF
--- a/converter/convert_bik_to_webm.ps1
+++ b/converter/convert_bik_to_webm.ps1
@@ -11,5 +11,5 @@ Get-ChildItem -Path $BIKDir -Filter *.bik | Foreach-Object {
 	}
 	$FileName = $WEBMRelDir + '/' + ($_.Name -replace "bik$", "webm")
 
-	ffmpeg -y -i $_.FullName -codec:v libvpx-vp9 -crf 12 -b:v 0 -codec:a libvorbis $FileName
+	ffmpeg -y -i $_.FullName -codec:v libvpx-vp9 -crf 16 -b:v 0 -map 0:v -codec:a libvorbis -map 0:a $FileName
 }

--- a/converter/convert_bik_to_webm.ps1
+++ b/converter/convert_bik_to_webm.ps1
@@ -11,5 +11,5 @@ Get-ChildItem -Path $BIKDir -Filter *.bik | Foreach-Object {
 	}
 	$FileName = $WEBMRelDir + '/' + ($_.Name -replace "bik$", "webm")
 
-	ffmpeg -y -i $_.FullName -codec:v libvpx-vp9 -crf 16 -b:v 0 -map 0:v -codec:a libvorbis -map 0:a $FileName
+	ffmpeg -y -i $_.FullName -codec:v vp8 -crf 16 -b:v 8M -map 0:v -codec:a libvorbis -map 0:a $FileName
 }

--- a/converter/convert_bik_to_webm.ps1
+++ b/converter/convert_bik_to_webm.ps1
@@ -11,5 +11,5 @@ Get-ChildItem -Path $BIKDir -Filter *.bik | Foreach-Object {
 	}
 	$FileName = $WEBMRelDir + '/' + ($_.Name -replace "bik$", "webm")
 
-	ffmpeg -y -i $_.FullName -codec:v vp8 -crf 16 -b:v 8M -map 0:v -codec:a libvorbis -map 0:a $FileName
+	ffmpeg -y -i $_.FullName -codec:v vp8 -crf 16 -b:v 8M -map 0:v -codec:a libvorbis -map 0:a? $FileName
 }


### PR DESCRIPTION
Embeds all audio channels into converted WebM videos and switches to VP8 codec with bitrate 8M.

Tested against l4d2_intro.bik with varying degrees of success.